### PR TITLE
Add support for submitting a follow-up job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-on: push
+on: [push, pull_request]
 jobs:
   qa:
     runs-on: ubuntu-latest

--- a/main/forms.py
+++ b/main/forms.py
@@ -57,6 +57,14 @@ class JobTypeForm(forms.Form):
         required=False,
     )
 
+    run_another = forms.BooleanField(
+        widget=forms.CheckboxInput(
+            attrs={"class": "ui checkbox",
+                   "style": "margin-top: 3px; margin-left: 8px;"}
+        ),
+        label="Run another job after submission:",
+        required=False)
+
 
 class ProjectForm(forms.ModelForm):
     class Meta:

--- a/main/templates/main/job_type.html
+++ b/main/templates/main/job_type.html
@@ -65,7 +65,13 @@
       {{ form.custom_config }}
       {{ form.custom_config.errors }}
     </div>
-    <input class="ui button" type="submit" value="Submit">
+    <div>
+        <input class="ui button" type="submit" value="Submit">
+        <span style="float: right; margin-top: 8px;">
+          <label for="{{ form.run_another_for_label }}" >{{ form.run_another.label }}</label>
+          {{ form.run_another }}
+        </span>
+    </div>
   </form>
 </div>
 {% endif %}

--- a/main/urls.py
+++ b/main/urls.py
@@ -9,12 +9,12 @@ app_name = "main"
 urlpatterns = [
     path("", views.index, name="index"),
     path(
-        "create_job/<int:project_pk>/<int:resource_index>/<int:software_index>/",
+        "create_job/<int:project_pk>/<int:resource_index>/<int:software_index>/<int:run_another>/",
         views.create_job,
         name="create_job",
     ),
     path(
-        "create_job/<int:project_pk>/<int:resource_index>/<int:software_index>/<int:config_pk>/",  # noqa: E501
+        "create_job/<int:project_pk>/<int:resource_index>/<int:software_index>/<int:run_another>/<int:config_pk>/",  # noqa: E501
         views.create_job,
         name="create_job",
     ),


### PR DESCRIPTION
This PR adds support for returning the user to the "Create job" form after submission of a job, with the originally specified form parameters pre-selected. This functionality is enabled by the user clicking a This simplifies the process of submitting multiple jobs and reduces the potential for error by incorrectly selecting the "Run another job after submission" checkbox.

There are various different ways to solve this and it may be that an alternative is preferred - I'm happy to modify things to fit in with your preferences. However, I've aimed to stick with the general structure of how things are set up at present, making minimal changes.

The implementation works by adding support for a set of query string parameters on the view behind the `job_type` endpoint. This approach was taken to avoid complicating the URL configuration for this endpoint but if named URL parameters are preferred, I can change this.

If the full set of query string parameters are provided (`p` for project ID, `r` for resource ID, `s` for software ID and `c` for custom configuration ID (optional, set to -1 if no custom configuration is set), the `JobTypeForm` object, from which the form is rendered, is pre-initialised with the set of provided values. This results in the form be setup with the specified items pre-selected.

Since there is a multi-stage submission process, the selected values when the job type form is initially submitted are carried through to the create job page (for which an additional URL parameter has been added to determine whether the `run_another` checkbox has been selected). These values are then used to setup the query string for the redirect URL sending the user back to the submission form.

**Known limitations**
 - At present, there's no way to provide confirmation, when returning the user to the job submission form, that the job submission was carried out successfully - we probably want something that displays the green alert banner above the job type form stating the ID of the submitted job. This could be done by adding that, along with a status flag, to the query string but not sure if this is the best approach.
 
  - There's no storing of context for the second stage of the submission form (i.e. file selection or description). This could be done but will add a fair bit of complexity in the context of file selection and would probbaly rely on JavaScript. Maybe this is not a requirement anyway.