### PR TITLE
Add an about page including citation information

### DIFF
--- a/main/templates/main/about.html
+++ b/main/templates/main/about.html
@@ -1,0 +1,58 @@
+{% extends "main/base.html" %}
+{% block content %}
+<div class="row">
+  <h1>About CHAMP</h1>
+</div>
+<div class="row">
+  <p>
+    <strong>
+        CHAMP v{{ APP_VERSION }}<br/>
+    </strong>
+    &copy; 2021 Imperial College London
+  </p>
+</div>
+<div class="row">
+  <p>
+    CHAMP is a web browser-based tool for simplifying the submission of
+    computational tasks to High Performance Computing (HPC) infrastructure.
+  </p>
+  <p>
+    Avoid the need to learn about using the command line, connecting to remote
+    system using tools like SSH or writing job submission scripts. Get the
+    benefits of HPC processing power directly through your browser!
+  </p>
+</div>
+
+<div class="row">
+  <h3>Citing CHAMP</h3>
+</div>
+<div class="row">
+  <p>
+    If you make use of CHAMP to support your research work, please cite the
+    following publication:
+  </p>
+  <p>
+    C. Cave-Ayland, M. Bearpark, C. Romain, H. Rzepa. CHAMP is a HPC Access and
+    Metadata Portal.<br/><em>Journal of Open Source Software</em> <strong>2022
+    </strong>, 7 (70), 3824.
+    <a href="https://doi.org/10.21105/joss.03824" target="_blank"
+       rel="noopener noreferrer">
+      https://doi.org/10.21105/joss.03824
+    </a>
+  </p>
+</div>
+
+<div class="row">
+  <h4>Related publications</h4>
+</div>
+<div class="row">
+  <p>
+    M. J. Harvey, N. J. Mason and H. S. Rzepa. Digital data repositories in
+    chemistry and their integration<br/>with journals and electronic
+    laboratory notebooks, <em>J. Chem. Inf. Model.</em>, <strong>2014
+    </strong>, 54, 2627–2635.<br/> DOI:
+    <a href="https://doi.org/10.1021/ci500302p" target="_blank"
+       rel="noopener noreferrer">10.1021/ci500302p</a>
+  </p>
+</div>
+{% endblock content %}

--- a/main/templates/main/about.html
+++ b/main/templates/main/about.html
@@ -1,17 +1,11 @@
 {% extends "main/base.html" %}
 {% block content %}
-<div class="row">
-  <h1>About CHAMP</h1>
-</div>
-<div class="row">
+<div class="ui text container">
+  <h1 class="ui header">About CHAMP</h1>
   <p>
-    <strong>
-        CHAMP v{{ APP_VERSION }}<br/>
-    </strong>
+    <strong>CHAMP v{{ APP_VERSION }}<br/></strong>
     &copy; 2021 Imperial College London
   </p>
-</div>
-<div class="row">
   <p>
     CHAMP is a web browser-based tool for simplifying the submission of
     computational tasks to High Performance Computing (HPC) infrastructure.
@@ -21,38 +15,30 @@
     system using tools like SSH or writing job submission scripts. Get the
     benefits of HPC processing power directly through your browser!
   </p>
-</div>
 
-<div class="row">
-  <h3>Citing CHAMP</h3>
-</div>
-<div class="row">
+  <h3 class="ui header">Citing CHAMP</h3>
   <p>
     If you make use of CHAMP to support your research work, please cite the
     following publication:
   </p>
   <p>
     C. Cave-Ayland, M. Bearpark, C. Romain, H. Rzepa. CHAMP is a HPC Access and
-    Metadata Portal.<br/><em>Journal of Open Source Software</em> <strong>2022
-    </strong>, 7 (70), 3824.
+    Metadata Portal.<br/><em>Journal of Open Source Software</em>
+    <strong>2022</strong>, 7 (70), 3824.
     <a href="https://doi.org/10.21105/joss.03824" target="_blank"
        rel="noopener noreferrer">
-      https://doi.org/10.21105/joss.03824
+       https://doi.org/10.21105/joss.03824
     </a>
   </p>
-</div>
 
-<div class="row">
-  <h4>Related publications</h4>
-</div>
-<div class="row">
+  <h4 class="ui header">Related publications</h4>
   <p>
     M. J. Harvey, N. J. Mason and H. S. Rzepa. Digital data repositories in
-    chemistry and their integration<br/>with journals and electronic
-    laboratory notebooks, <em>J. Chem. Inf. Model.</em>, <strong>2014
-    </strong>, 54, 2627–2635.<br/> DOI:
+    chemistry and their integration with journals and electronic
+    laboratory notebooks, <em>J. Chem. Inf. Model.</em>,
+    <strong>2014</strong>, 54, 2627–2635.<br/> DOI:
     <a href="https://doi.org/10.1021/ci500302p" target="_blank"
        rel="noopener noreferrer">10.1021/ci500302p</a>
-  </p>
+  </p> 
 </div>
 {% endblock content %}

--- a/main/templates/main/base.html
+++ b/main/templates/main/base.html
@@ -51,12 +51,13 @@
             <a href="{% url 'main:job_type' %}" class="item">Create Job</a>
             <a href="{% url 'main:list_jobs' %}" class="item">List All Jobs</a>
             <a href="{% url 'main:profile' %}" class="item">Profile</a>
-	    {% for link in EXTERNAL_LINKS %}
+            {% for link in EXTERNAL_LINKS %}
             <a href="{{ link.url }}" target="_blank" class="item external-link">{{ link.text }}</a>
-	    {% endfor %}
-	    <div class="right menu">
-	      <div class="item">{{ APP_NAME }} v{{ APP_VERSION }}</div>
-	    </div>
+            {% endfor %}
+            <div class="right menu">
+                <a href="{% url 'main:about' %}" class="item">About CHAMP</a>
+                <div class="item">{{ APP_NAME }} v{{ APP_VERSION }}</div>
+            </div>
         </div>
     </div>
 

--- a/main/urls.py
+++ b/main/urls.py
@@ -8,6 +8,7 @@ app_name = "main"
 
 urlpatterns = [
     path("", views.index, name="index"),
+    path("about/", views.about, name="about"),
     path(
         "create_job/<int:project_pk>/<int:resource_index>/<int:software_index>/",
         views.create_job,

--- a/main/views.py
+++ b/main/views.py
@@ -45,6 +45,11 @@ def index(request):
     return render(request, "main/index.html", {"admin_email": admin_email})
 
 
+def about(request):
+    """The about view"""
+    return render(request, "main/about.html")
+
+
 def create_job(request, project_pk, resource_index, software_index, config_pk=None):
     """This view handles a form that when submitted triggers creation of a job.
 


### PR DESCRIPTION
This PR adds a new "about" page which provides a brief description of CHAMP and details related to publications and citation.

The about page is accessed via a new "About CHAMP" link in the top right of the menu bar alongside the software version text.

Closes #73.